### PR TITLE
Create .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/


### PR DESCRIPTION
Added .gitignore to avoid all the clutter of node_modules. As it makes cloning of the repo too bulky. 